### PR TITLE
Release 3DS v2.8 fixed camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ user must provide their own legally obtained USA, unheadered ROM on their own
   game speed depend on when a VBlank wait returns.
 - Parallel PPU scanline rendering on Core 0 and Core 1, plus Core 2 on New 3DS,
   with persistent tile-row caches and frame-time diagnostics in quick dumps.
-- HOME Menu metadata is versioned for each build. v2.7 appears as
-  `Zelda ALttP 3DS` / `Zelda A Link to the Past 3DS v2.7`.
+- HOME Menu metadata is versioned for each build. v2.8 appears as
+  `A Link to the Past 3DS v2.8`.
 - HOME Menu banner uses a lightweight CGFX 3D box model with the supplied
   hover sound converted to a short PCM WAV.
 

--- a/app/jni/src/src/dungeon.c
+++ b/app/jni/src/src/dungeon.c
@@ -6501,7 +6501,45 @@ void LoadOWMusicIfNeeded() {  // 82854c
   LoadOverworldSongs();
 }
 
+static void Dungeon_ClampFixedCameraToBounds() {
+  int margin = ZeldaGetWidescreenFixedCameraMargin();
+  int qm = quadrant_fullsize_x >> 1;
+  uint16 left = room_bounds_x.v[qm];
+  uint16 width = room_bounds_x.v[qm + 2] - left;
+  if (!margin || width <= margin * 2)
+    return;
+
+  uint16 offset = BG2HOFS_copy2 - left;
+  uint16 target = BG2HOFS_copy2;
+  if (offset < margin)
+    target = left + margin;
+  else if (offset > width - margin)
+    target = left + width - margin;
+  if (target == BG2HOFS_copy2)
+    return;
+
+  uint16 delta = target - BG2HOFS_copy2;
+  BG2HOFS_copy2 = target;
+  camera_x_coord_scroll_low += delta;
+  camera_x_coord_scroll_hi += delta;
+
+  if (dungeon_room_index != 0xffff) {
+    if (dung_hdr_bg2_properties == 0 || dung_hdr_bg2_properties == 2 ||
+        dung_hdr_bg2_properties == 3 || dung_hdr_bg2_properties == 4 ||
+        dung_hdr_bg2_properties >= 6) {
+      BG1HOFS_copy2 = BG2HOFS_copy2;
+    } else {
+      uint32 fixed = BG1HOFS_subpixel | BG1HOFS_copy2 << 16;
+      fixed += (int16)delta * 0x8000;
+      BG1HOFS_subpixel = (uint16)fixed;
+      BG1HOFS_copy2 = (uint16)(fixed >> 16);
+    }
+  }
+}
+
 void Module07_Dungeon() {  // 8287a2
+  if (submodule_index == 0)
+    Dungeon_ClampFixedCameraToBounds();
   Dungeon_HandleLayerEffect();
   kDungeonSubmodules[submodule_index]();
 
@@ -8126,7 +8164,14 @@ void Dungeon_HandleCamera() {  // 82ba31
           continue;
         qm += 2;
       }
-      if (BG2HOFS_copy2 == room_bounds_x.v[qm])
+      uint16 camera_limit = room_bounds_x.v[qm];
+      int margin = ZeldaGetWidescreenFixedCameraMargin();
+      int left_bound = room_bounds_x.v[quadrant_fullsize_x >> 1];
+      int right_bound = room_bounds_x.v[(quadrant_fullsize_x >> 1) + 2];
+      if (right_bound - left_bound > margin * 2)
+        camera_limit += (qm >= 2) ? -margin : margin;
+      if ((scrollamt < 0 && BG2HOFS_copy2 <= camera_limit) ||
+          (scrollamt > 0 && BG2HOFS_copy2 >= camera_limit))
         continue;
       BG2HOFS_copy2 += scrollamt;
       if (dungeon_room_index == 0xffff)
@@ -8178,7 +8223,12 @@ void DungeonTransition_ScrollRoom() {  // 82be03
       link_y_coord += kStaircaseTab3[i];
   }
 
-  if ((t & 0x1fc) == (&up_down_scroll_target)[i]) {
+  uint16 target = (&up_down_scroll_target)[i];
+  if (i >= 2) {
+    int margin = ZeldaGetWidescreenFixedCameraMargin();
+    target += (i == 2) ? margin : -margin;
+  }
+  if ((t & 0x1fc) == (target & 0x1fc)) {
     SetAndSaveVisitedQuadrantFlags();
     subsubmodule_index++;
     transition_counter = 0;

--- a/app/jni/src/src/main.c
+++ b/app/jni/src/src/main.c
@@ -757,13 +757,6 @@ int main(int argc, char** argv) {
     HandleCommand(kKeys_Load + 0, true);
 
   while(running) {
-#ifdef __3DS__
-    if (!aptMainLoop()) {
-      Platform3DS_LogRuntime("APT requested application shutdown");
-      running = false;
-      break;
-    }
-#endif
     while(SDL_PollEvent(&event)) {
       if (SecondScreenSDL_HandleEvent(&event))
         continue;

--- a/app/jni/src/src/overworld.c
+++ b/app/jni/src/src/overworld.c
@@ -9,6 +9,7 @@
 #include "misc.h"
 #include "messaging.h"
 #include "player_oam.h"
+#include "zelda_rtl.h"
 #include "snes/snes_regs.h"
 #include "assets.h"
 
@@ -701,7 +702,55 @@ void ResetAncillaAndCutscene() {  // 829e6e
   flag_is_link_immobilized = 0;
 }
 
+static void Overworld_ApplyHorizontalCameraDelta(uint16 delta) {
+  WORD(byte_7E069E[1]) = delta;
+  uint8 oi = BYTE(overlay_index);
+  if (oi == 0x97 || oi == 0x9d || delta == 0)
+    return;
+
+  uint16 subpixel;
+  if (oi == 0x95 || oi == 0x9e) {
+    subpixel = (delta & 3) << 14;
+    delta >>= 2;
+    if (delta >= 0x3000)
+      delta |= 0xf000;
+  } else {
+    subpixel = (delta & 1) << 15;
+    delta >>= 1;
+    if (delta >= 0x7000)
+      delta |= 0xf000;
+  }
+  uint32 tmp = BG1HOFS_subpixel | BG1HOFS_copy2 << 16;
+  tmp += subpixel | delta << 16;
+  BG1HOFS_subpixel = (uint16)tmp;
+  BG1HOFS_copy2 = (uint16)(tmp >> 16);
+}
+
+static void Overworld_ClampFixedCameraToBounds() {
+  int margin = ZeldaGetWidescreenFixedCameraMargin();
+  uint16 width = ow_scroll_vars0.xend - ow_scroll_vars0.xstart;
+  if (!margin || width <= margin * 2)
+    return;
+
+  uint16 offset = BG2HOFS_copy2 - ow_scroll_vars0.xstart;
+  uint16 target = BG2HOFS_copy2;
+  if (offset < margin)
+    target = ow_scroll_vars0.xstart + margin;
+  else if (offset > width - margin)
+    target = ow_scroll_vars0.xstart + width - margin;
+  if (target == BG2HOFS_copy2)
+    return;
+
+  uint16 delta = target - BG2HOFS_copy2;
+  BG2HOFS_copy2 = target;
+  camera_x_coord_scroll_low += delta;
+  camera_x_coord_scroll_hi += delta;
+  Overworld_ApplyHorizontalCameraDelta(delta);
+}
+
 void Module09_Overworld() {  // 82a475
+  if (submodule_index == 0)
+    Overworld_ClampFixedCameraToBounds();
   kOverworldSubmodules[submodule_index]();
 
   int bg2x = BG2HOFS_copy2;
@@ -917,8 +966,15 @@ void Module09_LoadNewMapAndGFX() {  // 82abc6
 void Overworld_RunScrollTransition() {  // 82abda
   Link_HandleMovingAnimation_FullLongEntry();
   Graphics_IncrementalVRAMUpload();
-  uint8 rv = OverworldScrollTransition();
-  if (!(rv & 0xf)) {
+  bool fixed_horizontal =
+      ZeldaGetWidescreenFixedCameraMargin() &&
+      overworld_screen_transition >= 2;
+  uint16 previous_scroll = fixed_horizontal ? BG2HOFS_copy2 : 0;
+  uint16 rv = OverworldScrollTransition();
+  bool crossed_tile_boundary = fixed_horizontal ?
+      (previous_scroll >> 4) != (rv >> 4) :
+      !(rv & 0xf);
+  if (crossed_tile_boundary) {
     BYTE(overworld_screen_trans_dir_bits2) = BYTE(overworld_screen_trans_dir_bits);
     OverworldTransitionScrollAndLoadMap();
     BYTE(overworld_screen_trans_dir_bits2) = 0;
@@ -1579,7 +1635,7 @@ void Overworld_OperateCameraScroll() {  // 82bb90
   if (link_x_vel != 0) {
     int vx = sign8(link_x_vel) ? -1 : 1;
     int ax = sign8(link_x_vel) ? (link_x_vel ^ 0xff) + 1 : link_x_vel;
-    uint16 r4 = 0, subp;
+    uint16 r4 = 0;
     do {
       if (sign8(link_x_vel)) {
         if (x <= camera_x_coord_scroll_low)
@@ -1589,24 +1645,7 @@ void Overworld_OperateCameraScroll() {  // 82bb90
           r4 += OverworldCameraBoundaryCheck(0, 6, vx, 4);
       }
     } while (--ax);
-    WORD(byte_7E069E[1]) = r4;
-    uint8 oi = BYTE(overlay_index);
-    if (oi != 0x97 && oi != 0x9d && r4 != 0) {
-      if (oi == 0x95 || oi == 0x9e) {
-        subp = (r4 & 3) << 14;
-        r4 >>= 2;
-        if (r4 >= 0x3000)
-          r4 |= 0xf000;
-      } else {
-        subp = (r4 & 1) << 15;
-        r4 >>= 1;
-        if (r4 >= 0x7000)
-          r4 |= 0xf000;
-      }
-      uint32 tmp = BG1HOFS_subpixel | BG1HOFS_copy2 << 16;
-      tmp += subp | r4 << 16;
-      BG1HOFS_subpixel = (uint16)(tmp), BG1HOFS_copy2 = (uint16)(tmp >> 16);
-    }
+    Overworld_ApplyHorizontalCameraDelta(r4);
   }
   if (BYTE(overworld_screen_index) != 0x47) {
     if (BYTE(overlay_index) == 0x9c) {
@@ -1635,7 +1674,15 @@ int OverworldCameraBoundaryCheck(int xa, int ya, int vd, int r8) {  // 82bd62
 
   uint16 *xp = (xa ? &BG2VOFS_copy2 : &BG2HOFS_copy2);
   uint16 *yp = &(&ow_scroll_vars0.ystart)[ya];
-  if (*xp == *yp) {
+  uint16 camera_limit = *yp;
+  if (!xa) {
+    int margin = ZeldaGetWidescreenFixedCameraMargin();
+    uint16 width = ow_scroll_vars0.xend - ow_scroll_vars0.xstart;
+    if (width > margin * 2)
+      camera_limit += (ya & 1) ? -margin : margin;
+  }
+  if ((vd < 0 && *xp <= camera_limit) ||
+      (vd > 0 && *xp >= camera_limit)) {
     (&overworld_unk1)[ya] = 0;
     (&overworld_unk1)[ya ^ 1] = 0;
     return 0;
@@ -1680,7 +1727,10 @@ int OverworldScrollTransition() {  // 82c001
       BG1HOFS_copy2 = BG2HOFS_copy2;
     if (transition_counter >= kOverworld_Func6B_Tab2[y])
       link_x_coord += d;
-    if (rv != (&up_down_scroll_target)[y])
+    uint16 target = (&up_down_scroll_target)[y];
+    int margin = ZeldaGetWidescreenFixedCameraMargin();
+    target += (y == 2) ? margin : -margin;
+    if (rv != target)
       return rv;
     link_x_coord &= ~7;
     camera_x_coord_scroll_hi = link_x_coord + kOverworld_Func6B_Tab3[y] + 11;

--- a/app/jni/src/src/player_oam.c
+++ b/app/jni/src/src/player_oam.c
@@ -759,6 +759,25 @@ void CalculateSwordHitBox() {  // 879e63
   player_oam_x_offset = kSwordOamXOffs[i];
 }
 
+static void LinkOam_ApplyWidescreenX(uint16 screen_x) {
+  if (!ZeldaGetWidescreenFixedCameraMargin())
+    return;
+
+  // Most of Link's drawing code intentionally keeps only the SNES low X
+  // byte. In fixed-camera mode Link can occupy the added pixels at either
+  // side, so reconstruct each piece's OAM high bit from its signed position
+  // relative to Link. This changes only Link's twelve reserved OAM entries;
+  // unrelated sprites keep their native coordinates.
+  int base_x = (int16)screen_x;
+  int oam_pos = sort_sprites_offset_into_oam_buffer >> 2;
+  for (int i = 0; i < 12; i++) {
+    OamEnt *oam = &oam_buf[oam_pos + i];
+    int x = base_x + (int8)(oam->x - (uint8)base_x);
+    bytewise_extended_oam[oam_pos + i] =
+        (bytewise_extended_oam[oam_pos + i] & ~1) | ((x >> 8) & 1);
+  }
+}
+
 void LinkOam_Main() {  // 8da18e
   uint16 y_coord_backup = link_y_coord;
 
@@ -769,7 +788,8 @@ void LinkOam_Main() {  // 8da18e
     link_y_coord += kPlayerOam_StairsOffsY[t];
   }
 
-  uint8 xcoord = link_x_coord - BG2HOFS_copy2;
+  uint16 screen_x = link_x_coord - BG2HOFS_copy2;
+  uint8 xcoord = screen_x;
   uint8 ycoord = link_y_coord - BG2VOFS_copy2;
   player_oam_x_offset = player_oam_y_offset = 0x80;
   uint8 scratch_0_var = (draw_water_ripples_or_grass != 0);
@@ -1097,7 +1117,16 @@ continue_after_set:
 
   uint16 t;
   bool hide_shadow = true;
-  if (is_standing_in_doorway && ((t = link_x_coord - BG2HOFS_copy2) < 4 || t >= 252 || (t = link_y_coord - BG2VOFS_copy2) < 4 || t >= 224) ||
+  int fixed_margin = ZeldaGetWidescreenFixedCameraMargin();
+  int16 screen_x_signed = (int16)screen_x;
+  bool outside_horizontal_doorway =
+      fixed_margin ?
+      (screen_x_signed < 4 - fixed_margin ||
+       screen_x_signed >= 252 + fixed_margin) :
+      ((t = link_x_coord - BG2HOFS_copy2) < 4 || t >= 252);
+  if (is_standing_in_doorway &&
+      (outside_horizontal_doorway ||
+       (t = link_y_coord - BG2VOFS_copy2) < 4 || t >= 224) ||
       (hide_shadow = false,
       submodule_index == 0 && countdown_for_blink && --countdown_for_blink >= 4 && (countdown_for_blink & 1) == 0 ||
       link_visibility_status == 12 ||
@@ -1126,6 +1155,8 @@ continue_after_set:
         WORD(p[shadow_oam_pos]) = 0;
     }
   }
+
+  LinkOam_ApplyWidescreenX(screen_x);
 
   if (submodule_index == 18 || submodule_index == 19)
     link_y_coord = y_coord_backup;

--- a/app/jni/src/src/zelda_rtl.c
+++ b/app/jni/src/src/zelda_rtl.c
@@ -151,25 +151,20 @@ static void SimpleHdma_DoLine(SimpleHdma *c, Ppu *ppu) {
   c->rep_count--;
 }
 
-static bool IsOverworldSpecialBg1Area(void) {
-  return main_module_index == 9 &&
-      (BYTE(overworld_screen_index) & 0x3f) == 0x1b;
+static bool IsFixedCameraHorizontalTransition(int mod) {
+  if (g_widescreen_edge_mode != 1 || overworld_screen_transition < 2)
+    return false;
+  if (main_module_index == 9 && mod == 9)
+    return submodule_index >= 1 && submodule_index <= 8;
+  if (main_module_index == 7 && mod == 7)
+    return submodule_index == 2;
+  return false;
 }
 
-static uint16 GetOverworldSpecialBg1HScroll(uint16 bg2_hofs,
-                                            uint16 bg1_hofs) {
-  int16 parallax = (int16)(BG2HOFS_copy2 - 0x778) >> 1;
-  uint16 expected_current = BG2HOFS_copy2 - parallax;
-  uint16 offset = (bg1_hofs - expected_current) & 0x3ff;
-  parallax = (int16)(bg2_hofs - 0x778) >> 1;
-  return (uint16)(bg2_hofs - parallax + offset) & 0x3ff;
-}
-
-static void ConfigurePpuSideSpace(uint16 camera_x, bool use_camera_x) {
+static void ConfigurePpuSideSpace() {
   // Let PPU impl know about the maximum allowed extra space on the sides and bottom
   int extra_right = 0, extra_left = 0, extra_bottom = 0;
 //  printf("main %d, sub %d  (%d, %d, %d)\n", main_module_index, submodule_index, BG2HOFS_copy2, room_bounds_x.v[2 | (quadrant_fullsize_x >> 1)], quadrant_fullsize_x >> 1);
-  int bg2_hofs = use_camera_x ? camera_x : BG2HOFS_copy2;
   int mod = main_module_index;
   if (mod == 14)
     mod = saved_module_for_menu;
@@ -184,16 +179,16 @@ static void ConfigurePpuSideSpace(uint16 camera_x, bool use_camera_x) {
       extra_bottom = 16;
     } else {
       // outdoors
-      extra_left = bg2_hofs - ow_scroll_vars0.xstart;
-      extra_right = ow_scroll_vars0.xend - bg2_hofs;
+      extra_left = BG2HOFS_copy2 - ow_scroll_vars0.xstart;
+      extra_right = ow_scroll_vars0.xend - BG2HOFS_copy2;
       extra_bottom = ow_scroll_vars0.yend - BG2VOFS_copy2;
     }
   } else if (mod == 7) {
     // indoors, except when the light cone is in use
     if (!(hdr_dungeon_dark_with_lantern && TS_copy != 0)) {
       int qm = quadrant_fullsize_x >> 1;
-      extra_left = IntMax(bg2_hofs - room_bounds_x.v[qm], 0);
-      extra_right = IntMax(room_bounds_x.v[qm + 2] - bg2_hofs, 0);
+      extra_left = IntMax(BG2HOFS_copy2 - room_bounds_x.v[qm], 0);
+      extra_right = IntMax(room_bounds_x.v[qm + 2] - BG2HOFS_copy2, 0);
     }
 
     int qy = quadrant_fullsize_y >> 1;
@@ -202,6 +197,12 @@ static void ConfigurePpuSideSpace(uint16 camera_x, bool use_camera_x) {
     extra_left = kPpuExtraLeftRight, extra_right = kPpuExtraLeftRight;
     extra_bottom = 16;
   }
+  // During a real horizontal room/map transition both neighboring tilemaps
+  // are resident. Keep the entire widescreen viewport enabled while the
+  // native camera crosses between them instead of blanking the side that is
+  // temporarily outside the old area's bounds.
+  if (IsFixedCameraHorizontalTransition(mod))
+    extra_left = extra_right = kPpuExtraLeftRight;
   PpuSetExtraSideSpace(g_zenv.ppu, extra_left, extra_right, extra_bottom);
 }
 
@@ -220,95 +221,9 @@ int ZeldaGetWidescreenFixedCameraMargin(void) {
       !g_zenv.ppu || g_zenv.ppu->extraLeftRight == 0 ||
       (main_module_index != 7 && main_module_index != 9))
     return 0;
-  if (main_module_index == 7 && submodule_index != 0)
-    return 0;
   if (main_module_index == 7 && hdr_dungeon_dark_with_lantern && TS_copy != 0)
     return 0;
   return g_zenv.ppu->extraLeftRight;
-}
-
-typedef struct FixedCameraRenderState {
-  bool active;
-  uint16 visual_x;
-  uint16 ppu_bg1_hscroll;
-  uint16 ppu_bg2_hscroll;
-  uint16 oam[0x110];
-} FixedCameraRenderState;
-
-static void ShiftRenderOamX(Ppu *ppu, int delta) {
-  for (int i = 0; i < 128; i++) {
-    int word_index = i * 2;
-    int ext_index = 0x100 + (word_index >> 4);
-    int shift = word_index & 15;
-    int high = (ppu->oam[ext_index] >> shift) & 1;
-    int x = (ppu->oam[word_index] & 0xff) + high * 256;
-    if (x >= 256 + ppu->extraLeftRight)
-      x -= 512;
-    x += delta;
-    int encoded = x & 0x1ff;
-    ppu->oam[word_index] = (ppu->oam[word_index] & 0xff00) | (encoded & 0xff);
-    ppu->oam[ext_index] =
-        (ppu->oam[ext_index] & ~(1u << shift)) |
-        (((encoded >> 8) & 1) << shift);
-  }
-}
-
-static uint16 ClampHorizontalCameraForRender(void) {
-  int margin = ZeldaGetWidescreenFixedCameraMargin();
-  if (!margin)
-    return BG2HOFS_copy2;
-
-  int left, right;
-  if (main_module_index == 7) {
-    int qm = quadrant_fullsize_x >> 1;
-    left = room_bounds_x.v[qm] + margin;
-    right = room_bounds_x.v[qm + 2] - margin;
-  } else {
-    left = ow_scroll_vars0.xstart + margin;
-    right = ow_scroll_vars0.xend - margin;
-  }
-  int current = BG2HOFS_copy2;
-  if (right < left)
-    return BG2HOFS_copy2;
-  if (current < left)
-    return (uint16)left;
-  if (current > right)
-    return (uint16)right;
-  return BG2HOFS_copy2;
-}
-
-static FixedCameraRenderState BeginFixedCameraRender(void) {
-  FixedCameraRenderState state = {0};
-  uint16 visual_x = ClampHorizontalCameraForRender();
-  if (visual_x == BG2HOFS_copy2)
-    return state;
-
-  state.active = true;
-  state.visual_x = visual_x;
-  state.ppu_bg1_hscroll = g_zenv.ppu->bgLayer[0].hScroll;
-  state.ppu_bg2_hscroll = g_zenv.ppu->bgLayer[1].hScroll;
-  memcpy(state.oam, g_zenv.ppu->oam, sizeof(state.oam));
-
-  int delta = (int)BG2HOFS_copy2 - (int)visual_x;
-  if (IsOverworldSpecialBg1Area()) {
-    g_zenv.ppu->bgLayer[0].hScroll =
-        GetOverworldSpecialBg1HScroll(visual_x,
-                                      state.ppu_bg1_hscroll);
-  } else {
-    g_zenv.ppu->bgLayer[0].hScroll =
-        (state.ppu_bg1_hscroll - delta) & 0x3ff;
-  }
-  g_zenv.ppu->bgLayer[1].hScroll = visual_x & 0x3ff;
-  ShiftRenderOamX(g_zenv.ppu, delta);
-  return state;
-}
-
-static void EndFixedCameraRender(const FixedCameraRenderState *state) {
-  if (!state->active)
-    return;
-  g_zenv.ppu->bgLayer[0].hScroll = state->ppu_bg1_hscroll;
-  g_zenv.ppu->bgLayer[1].hScroll = state->ppu_bg2_hscroll;
-  memcpy(g_zenv.ppu->oam, state->oam, sizeof(state->oam));
 }
 
 static void ZeldaDrawPpuLines(Ppu *ppu, int height,
@@ -485,11 +400,8 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
       PpuSetMode7PerspectiveCorrection(g_zenv.ppu, 0, 0);
   }
 
-  FixedCameraRenderState fixed_camera_state = BeginFixedCameraRender();
-
   if (g_zenv.ppu->extraLeftRight != 0 || render_flags & kPpuRenderFlags_Height240)
-    ConfigurePpuSideSpace(fixed_camera_state.visual_x,
-                          fixed_camera_state.active);
+    ConfigurePpuSideSpace();
 
   PpuSetWindow1Ext(g_zenv.ppu, g_spotlight_ext_active ? g_spotlight_ext_left : NULL,
                    g_spotlight_ext_active ? g_spotlight_ext_right : NULL);
@@ -555,7 +467,6 @@ void ZeldaDrawPpuFrame(uint8 *pixel_buffer, size_t pitch, uint32 render_flags) {
     irq_flag = 0;
     zelda_snes_dummy_write(NMITIMEN, 0x81);
   }
-  EndFixedCameraRender(&fixed_camera_state);
 }
 
 void HdmaSetup(uint32 addr6, uint32 addr7, uint8 transfer_unit, uint8 reg6, uint8 reg7, uint8 indirect_bank) {

--- a/platform/3ds/CMakeLists.txt
+++ b/platform/3ds/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(zelda3_3ds VERSION 2.7 LANGUAGES C)
+project(zelda3_3ds VERSION 2.8 LANGUAGES C)
 
 set(ZELDA3_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
 set(ZELDA3_NATIVE "${ZELDA3_ROOT}/app/jni/src")
@@ -52,7 +52,7 @@ target_include_directories(zelda3-3ds PRIVATE
 
 target_compile_definitions(zelda3-3ds PRIVATE
   SYSTEM_VOLUME_MIXER_AVAILABLE=0
-  ZELDA3_3DS_VERSION=\"2.7\"
+  ZELDA3_3DS_VERSION=\"2.8\"
   NDEBUG=1
 )
 
@@ -94,15 +94,15 @@ configure_file(
 set(ZELDA3_SMDH "${CMAKE_CURRENT_BINARY_DIR}/zelda3-3ds.smdh")
 ctr_generate_smdh(
   OUTPUT "${ZELDA3_SMDH}"
-  NAME "Zelda ALttP 3DS"
-  DESCRIPTION "Zelda A Link to the Past 3DS v2.7"
+  NAME "A Link to the Past 3DS v2.8"
+  DESCRIPTION "A Link to the Past 3DS v2.8"
   AUTHOR "snesrev, samyost1, 3DS port"
   ICON "${CMAKE_CURRENT_LIST_DIR}/assets/icon.png"
 )
 
 ctr_create_3dsx(zelda3-3ds-3dsx
   TARGET zelda3-3ds
-  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/zelda3-3ds-v2.7.3dsx"
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/zelda3-3ds-v2.8.3dsx"
   SMDH "${ZELDA3_SMDH}"
   ROMFS "${ZELDA3_ROMFS}"
 )

--- a/platform/3ds/README.md
+++ b/platform/3ds/README.md
@@ -34,11 +34,11 @@ once per VBlank, while the bottom UI redraws at 30 FPS. Quick-dump `info.txt`
 files include average/max frame work time and the number of frames that exceed
 the 16.67 ms budget.
 
-The HOME Menu metadata is versioned for every release. v2.7 uses:
+The HOME Menu metadata is versioned for every release. v2.8 uses:
 
 ```text
-Short name: Zelda ALttP 3DS
-Long name:  Zelda A Link to the Past 3DS v2.7
+Short name: A Link to the Past 3DS v2.8
+Long name:  A Link to the Past 3DS v2.8
 ```
 
 The CIA banner prefers `assets/banner.cgfx` when present. v1.6 uses a real

--- a/platform/3ds/build.sh
+++ b/platform/3ds/build.sh
@@ -42,8 +42,8 @@ if [[ ! -x "${MAKEROM}" || ! -x "${BANNERTOOL}" ]]; then
 fi
 
 "${BANNERTOOL}" makesmdh \
-  -s "Zelda ALttP 3DS" \
-  -l "Zelda A Link to the Past 3DS v2.7" \
+  -s "A Link to the Past 3DS v2.8" \
+  -l "A Link to the Past 3DS v2.8" \
   -p "snesrev / samyost1 / 3DS port" \
   -i "${ROOT}/platform/3ds/assets/icon.png" \
   -f visible,nosavebackups \
@@ -65,7 +65,7 @@ fi
   cd "${ROOT}"
   "${MAKEROM}" \
     -f cia \
-    -o "${GAME_BUILD}/zelda3-3ds-v2.7.cia" \
+    -o "${GAME_BUILD}/zelda3-3ds-v2.8.cia" \
     -DAPP_ROMFS=build-3ds/game/romfs \
     -rsf platform/3ds/cia/zelda3.rsf \
     -target t \
@@ -76,5 +76,5 @@ fi
 )
 
 printf 'Listos:\n'
-printf '  %s\n' "${GAME_BUILD}/zelda3-3ds-v2.7.3dsx"
-printf '  %s\n' "${GAME_BUILD}/zelda3-3ds-v2.7.cia"
+printf '  %s\n' "${GAME_BUILD}/zelda3-3ds-v2.8.3dsx"
+printf '  %s\n' "${GAME_BUILD}/zelda3-3ds-v2.8.cia"

--- a/platform/3ds/cia/zelda3.rsf
+++ b/platform/3ds/cia/zelda3.rsf
@@ -1,5 +1,5 @@
 BasicInfo:
-  Title: "Zelda ALttP 3DS"
+  Title: "ALttP 3DS v2.8"
   ProductCode: "CTR-P-Z3DS"
   Logo: Homebrew
 

--- a/platform/3ds/romfs/zelda3.ini
+++ b/platform/3ds/romfs/zelda3.ini
@@ -3,6 +3,7 @@ Autosave = 1
 DisplayPerfInTitle = 0
 ExtendedAspectRatio = 4:3
 DisplayMode = Stretch
+WideEdgeMode = FixedCamera
 DisableFrameDelay = 1
 CStickTurboMultiplier = 5
 SecondScreenXItemRing = 1


### PR DESCRIPTION
## Summary
- Restore fixed-camera widescreen behavior from a v1.8-style logical camera approach.
- Fix horizontal and vertical edge transitions without black borders, reversed motion, or opposite-side sprite artifacts.
- Update 3DS title/version metadata to A Link to the Past 3DS v2.8 and restore SDL-driven shutdown flow.

## Validation
- git diff --check
- ./platform/3ds/build.sh
- Verified generated SMDH title text: A Link to the Past 3DS v2.8
- Booted final build in Azahar; real hardware HOME Menu close still needs confirmation.