### PR TITLE
Wide mode vertical expand

### DIFF
--- a/app/jni/src/src/main.c
+++ b/app/jni/src/src/main.c
@@ -568,6 +568,13 @@ void ZeldaSet3DSDisplayMode(int mode) {
   if (!wide)
     PpuSetExtraSideSpace(g_zenv.ppu, 0, 0, 0);
   g_snes_width = extra * 2 + 256;
+// Check if we're in wide mode, and if so enable extended-vertical rendering on the PPU emulator, and set window to 240 pixels high
+  g_config.extend_y = wide;
+  g_snes_height = wide ? 240 : 224;
+  if (wide)
+    g_ppu_render_flags |= kPpuRenderFlags_Height240;
+  else
+    g_ppu_render_flags &= ~kPpuRenderFlags_Height240;
   ZeldaApplyRendererSize();
   Platform3DS_SetDisplayMode(display_mode);
 }

--- a/platform/3ds/source/platform_3ds.c
+++ b/platform/3ds/source/platform_3ds.c
@@ -2963,7 +2963,11 @@ void Platform3DS_ApplyConfig(struct Config *config) {
   config->enhanced_mode7 = false;
   config->new_renderer = true;
   config->no_sprite_limits = false;
-  config->extend_y = false;
+// Wide mode draws to the full 240px screen height (see
+// Platform3DS_PresentTopFrame), so the source frame must be 240 lines or
+// that draw stretches a 224-line frame by a fractional nearest-neighbor
+// scale. Tie extend_y to wide mode so the two stay in sync at boot too.
+  config->extend_y = g_display_mode == kPlatform3DSDisplayUltraWideMod;
   config->extended_aspect_ratio =
     g_display_mode == kPlatform3DSDisplayUltraWideMod ? 72 : 0;
   config->features0 &= ~(kFeatures0_ExtendScreen64 |


### PR DESCRIPTION
Fixes #23 

Adds 16 extra vertical pixels in wide mode to maintain 1:1 pixel mapping instead of having a slight non-integer vertical stretch.
Tested working in emulator.
Due to how the PPU renderer works these pixels have to be at the *bottom* of the viewport, it is not possible to remain 100% centered. But, it is difficult to notice unless directly comparing with original.

wide mode:
<img width="1618" height="969" alt="image" src="https://github.com/user-attachments/assets/09d011ab-328e-4727-97ba-d781d5df578e" />
original: (blurry due to being from different source)
<img width="2453" height="1839" alt="image" src="https://github.com/user-attachments/assets/0ce5d820-e7d8-4241-8dfc-b9ce1e619072" />
You can see additional grass tufts in the bottom/left. In original there is one visible, wide  mode showing the additional 16 pixels (to reach proper 400x240) reveals 2 more.

Original mode remains unchanged as it was fine before.